### PR TITLE
Adding support for GxGST sentences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Build results
+[Bb]uild
+
+demo_advanced
+demo_simple
+
+#CMake
+*.cmake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/include/nmeaparse/GPSFix.h
+++ b/include/nmeaparse/GPSFix.h
@@ -156,6 +156,14 @@ namespace nmea {
 		double horizontalDilution;			// Horizontal dilution of precision, initialized to 100, best =1, worst = >20
 		double verticalDilution;			// Vertical is less accurate
 
+		double rmsDeviation;				// Root mean square value of the standard deviation of the range inputs to the navigation process.
+		double semiMajorDeviation;			// Standard deviation of semi-major axis of error ellipse, in meters 
+		double semiMinorDeviation;			// Standard deviation of semi-minor axis of error ellipse, in meters
+		double semiMajorOrient;				// Orientation of semi-major axis of error ellipse (degrees from true north)
+		double latitudeDeviation;			// Standard deviation of latitude error (m)
+		double longitudeDeviation;			// Standard deviation of longitude error (m)
+		double altitudeDeviation;			// Standard deviation of altitude error (m)
+
 		double altitude;		// meters
 		double latitude;		// degrees N
 		double longitude;		// degrees E

--- a/include/nmeaparse/GPSService.h
+++ b/include/nmeaparse/GPSService.h
@@ -25,6 +25,7 @@ private:
 	void read_PSRF150(const NMEASentence& nmea);
 	void read_GxGGA	(const NMEASentence& nmea);
 	void read_GxGSA	(const NMEASentence& nmea);
+	void read_GxGST	(const NMEASentence& nmea);
 	void read_GxGSV	(const NMEASentence& nmea);
 	void read_GxRMC	(const NMEASentence& nmea);
 	void read_GxVTG	(const NMEASentence& nmea);


### PR DESCRIPTION
Using the GxGST information for horizontal and vertical accuracy output if valid GST sentences are found.
Otherwise calculating from the accuracy values given in the RTK1010 datasheet for Single and RTK fix.

Also added a .gitignore file 